### PR TITLE
Relax deployment target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
   name: "combine-schedulers",
   platforms: [
-    .iOS(.v13),
-    .macOS(.v10_15),
-    .tvOS(.v13),
-    .watchOS(.v6),
+    .iOS(.v10),
+    .macOS(.v10_12),
+    .tvOS(.v10),
+    .watchOS(.v3),
   ],
   products: [
     .library(

--- a/Sources/CombineSchedulers/AnyScheduler.swift
+++ b/Sources/CombineSchedulers/AnyScheduler.swift
@@ -1,3 +1,4 @@
+#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -114,6 +115,7 @@ import Foundation
 /// in classes, functions, etc. without needing to introduce a generic, which can help simplify
 /// the code and reduce implementation details from leaking out.
 ///
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public struct AnyScheduler<SchedulerTimeType, SchedulerOptions>: Scheduler
 where
   SchedulerTimeType: Strideable,
@@ -199,13 +201,16 @@ where
 
 /// A convenience type to specify an `AnyScheduler` by the scheduler it wraps rather than by the
 /// time type and options type.
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public typealias AnySchedulerOf<Scheduler> = AnyScheduler<
   Scheduler.SchedulerTimeType, Scheduler.SchedulerOptions
 > where Scheduler: Combine.Scheduler
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Scheduler {
   /// Wraps this scheduler with a type eraser.
   public func eraseToAnyScheduler() -> AnyScheduler<SchedulerTimeType, SchedulerOptions> {
     AnyScheduler(self)
   }
 }
+#endif

--- a/Sources/CombineSchedulers/ImmediateScheduler.swift
+++ b/Sources/CombineSchedulers/ImmediateScheduler.swift
@@ -1,3 +1,4 @@
+#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -97,6 +98,7 @@ import Foundation
 ///       XCTAssert(output, [Episode(id: 42)])
 ///     }
 ///
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public struct ImmediateScheduler<SchedulerTimeType, SchedulerOptions>: Scheduler
 where
   SchedulerTimeType: Strideable,
@@ -138,6 +140,7 @@ where
   }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Scheduler
 where
   SchedulerTimeType == DispatchQueue.SchedulerTimeType,
@@ -149,6 +152,7 @@ where
   }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Scheduler
 where
   SchedulerTimeType == RunLoop.SchedulerTimeType,
@@ -159,6 +163,7 @@ where
   }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Scheduler
 where
   SchedulerTimeType == OperationQueue.SchedulerTimeType,
@@ -171,6 +176,8 @@ where
 
 /// A convenience type to specify an `ImmediateTestScheduler` by the scheduler it wraps rather than
 /// by the time type and options type.
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public typealias ImmediateSchedulerOf<Scheduler> = ImmediateScheduler<
   Scheduler.SchedulerTimeType, Scheduler.SchedulerOptions
 > where Scheduler: Combine.Scheduler
+#endif

--- a/Sources/CombineSchedulers/TestScheduler.swift
+++ b/Sources/CombineSchedulers/TestScheduler.swift
@@ -1,3 +1,4 @@
+#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -55,6 +56,7 @@ import Foundation
 /// but this technique can be used to test any publisher that involves Combine's asynchronous
 /// operations.
 ///
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public final class TestScheduler<SchedulerTimeType, SchedulerOptions>: Scheduler
 where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeIntervalConvertible {
 
@@ -172,6 +174,7 @@ where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeInte
   }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Scheduler
 where
   SchedulerTimeType == DispatchQueue.SchedulerTimeType,
@@ -184,6 +187,7 @@ where
   }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Scheduler
 where
   SchedulerTimeType == RunLoop.SchedulerTimeType,
@@ -195,6 +199,7 @@ where
   }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Scheduler
 where
   SchedulerTimeType == OperationQueue.SchedulerTimeType,
@@ -208,6 +213,8 @@ where
 
 /// A convenience type to specify a `TestScheduler` by the scheduler it wraps rather than by the
 /// time type and options type.
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public typealias TestSchedulerOf<Scheduler> = TestScheduler<
   Scheduler.SchedulerTimeType, Scheduler.SchedulerOptions
 > where Scheduler: Combine.Scheduler
+#endif

--- a/Sources/CombineSchedulers/Timer.swift
+++ b/Sources/CombineSchedulers/Timer.swift
@@ -11,12 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 // Only support 64bit
-#if !(os(iOS) && (arch(i386) || arch(arm)))
-
+#if !(os(iOS) && (arch(i386) || arch(arm))) && canImport(Combine)
   @_exported import Foundation  // Clang module
   import Combine
   import Foundation
 
+  @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
   extension Scheduler {
     /// Returns a publisher that repeatedly emits the scheduler's current time on the given
     /// interval.

--- a/Sources/CombineSchedulers/UIScheduler.swift
+++ b/Sources/CombineSchedulers/UIScheduler.swift
@@ -1,5 +1,7 @@
+#if canImport(Combine)
 import Combine
 import Dispatch
+
 
 /// A scheduler that executes its work on the main queue as soon as possible.
 ///
@@ -14,6 +16,7 @@ import Dispatch
 /// This scheduler can be useful for situations where you need work executed as quickly as
 /// possible on the main thread, and for which a thread hop would be problematic, such as when
 /// performing animations.
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public struct UIScheduler: Scheduler {
   public typealias SchedulerOptions = Never
   public typealias SchedulerTimeType = DispatchQueue.SchedulerTimeType
@@ -61,3 +64,4 @@ public struct UIScheduler: Scheduler {
 private let key = DispatchSpecificKey<UInt8>()
 private let value: UInt8 = 0
 private var setSpecific: () = { DispatchQueue.main.setSpecific(key: key, value: value) }()
+#endif

--- a/Tests/CombineSchedulersTests/ImmediateSchedulerTests.swift
+++ b/Tests/CombineSchedulersTests/ImmediateSchedulerTests.swift
@@ -1,7 +1,9 @@
+#if canImport(Combine)
 import Combine
 import CombineSchedulers
 import XCTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class ImmediateSchedulerTests: XCTestCase {
   func testSchedulesImmediately() {
     let scheduler = DispatchQueue.immediateScheduler
@@ -17,3 +19,4 @@ final class ImmediateSchedulerTests: XCTestCase {
     XCTAssertEqual(worked, 3)
   }
 }
+#endif

--- a/Tests/CombineSchedulersTests/TestSchedulerTests.swift
+++ b/Tests/CombineSchedulersTests/TestSchedulerTests.swift
@@ -1,7 +1,9 @@
+#if canImport(Combine)
 import Combine
 import CombineSchedulers
 import XCTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class CombineSchedulerTests: XCTestCase {
   var cancellables: Set<AnyCancellable> = []
 
@@ -133,3 +135,4 @@ final class CombineSchedulerTests: XCTestCase {
     XCTAssertEqual(values, [1, 42, 42, 1, 42])
   }
 }
+#endif

--- a/Tests/CombineSchedulersTests/TimerTests.swift
+++ b/Tests/CombineSchedulersTests/TimerTests.swift
@@ -1,7 +1,9 @@
+#if canImport(Combine)
 import Combine
 import CombineSchedulers
 import XCTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class TimerTests: XCTestCase {
   var cancellables: Set<AnyCancellable> = []
 
@@ -139,3 +141,4 @@ final class TimerTests: XCTestCase {
     XCTAssertEqual(count, 3)
   }
 }
+#endif

--- a/Tests/CombineSchedulersTests/UISchedulerTests.swift
+++ b/Tests/CombineSchedulersTests/UISchedulerTests.swift
@@ -1,7 +1,9 @@
+#if canImport(Combine)
 import Combine
 import CombineSchedulers
 import XCTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class UISchedulerTests: XCTestCase {
   func testVoidsThreadHop() {
     var worked = false
@@ -29,3 +31,4 @@ final class UISchedulerTests: XCTestCase {
     XCTAssertTrue(worked)
   }
 }
+#endif


### PR DESCRIPTION
## What?
This PR lowers the deployment target across all platforms

## Why?
While Combine itself is iOS 13+, the consumers might not be. For example, product apps that still support iOS 10+ users but have _some_ features written using Combine.

We're deploying a similar strategy in CombineExt, CombineCocoa, RxCombine, etc. 