### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ A few schedulers that make working with Combine more testable and more versatile
 
 ## Motivation
 
-The Combine framework provides the `Scheduler` protocol, which is a powerful abstraction for describing how and when units of work are executed. It unifies many disparate ways of executing work, such as `DispatchQueue`, `RunLoop` and `OperationQueue`.
+The Combine framework provides the `Scheduler` protocol, which is a powerful abstraction for describing how and when units of work are executed. It unifies many disparate ways of executing work, such as `DispatchQueue`, `RunLoop` and `OperationQueue`. 
 
-However, the Combine framework is still quite new and missing some fundamental pieces needed to make asynchronous Combine code more testable. This library intends to fill those gaps with some handy schedulers and publishers.
+However, the moment you use any of these schedulers in your reactive code you instantly make the publisher asynchronous and therefore much harder to test, forcing you to use expectations and waits for time to pass as your publisher executes.
+
+This library provides new schedulers that allow you to turn any asynchronous publisher into a synchronous one for ease of testing and debugging.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A few schedulers that make working with Combine more testable and more versatile
 
 ## Motivation
 
-The Combine framework provides the `Scheduler` protocol, which is a powerful abstraction for describing how and when units of work are executed. It unifies many disparate ways of executing work, such as `DispatchQueue`, `RunLoop` and `OperationQueue`. 
+The Combine framework provides the `Scheduler` protocol, which is a powerful abstraction for describing how and when units of work are executed. It unifies many disparate ways of executing work, such as `DispatchQueue`, `RunLoop` and `OperationQueue`.
 
 However, the moment you use any of these schedulers in your reactive code you instantly make the publisher asynchronous and therefore much harder to test, forcing you to use expectations and waits for time to pass as your publisher executes.
 


### PR DESCRIPTION
Some discussions on twitter made me realize that we aren't being as explicit as we could be that these schedulers turn async publishers into sync ones. So wanted to try conveying that, but also open to suggestions.