### PR TITLE
Documentation fix: use autoconnect for timer.

### DIFF
--- a/Sources/CombineSchedulers/TestScheduler.swift
+++ b/Sources/CombineSchedulers/TestScheduler.swift
@@ -108,6 +108,7 @@
     ///
     ///     let scheduler = DispatchQueue.testScheduler
     ///     Publishers.Timer(every: .seconds(1), scheduler: scheduler)
+    ///       .autoconnect()
     ///       .sink { _ in print($0) }
     ///       .store(in: &cancellables)
     ///
@@ -119,6 +120,7 @@
     ///
     ///     let scheduler = DispatchQueue.testScheduler
     ///     Publishers.Timer(every: .seconds(1), scheduler: scheduler)
+    ///       .autoconnect()
     ///       .prefix(3)
     ///       .sink { _ in print($0) }
     ///       .store(in: &cancellables)

--- a/Sources/CombineSchedulers/Timer.swift
+++ b/Sources/CombineSchedulers/Timer.swift
@@ -52,6 +52,7 @@
     /// run loop:
     ///
     ///     Publishers.Timer(every: .seconds(1), scheduler: DispatchQueue.main)
+    ///       .autoconnect()
     ///       .sink { print("Timer", $0) }
     ///
     /// But more importantly, you can use it with `TestScheduler` so that any Combine code you write
@@ -62,6 +63,7 @@
     ///     var output: [Int] = []
     ///
     ///     Publishers.Timer(every: 1, scheduler: scheduler)
+    ///       .autoconnect()
     ///       .sink { _ in output.append(output.count) }
     ///       .store(in: &self.cancellables)
     ///


### PR DESCRIPTION
Just spotted this. I believe we need `.autoconnect()` for these timer publishers to start automatically.