### PR TITLE
Fix documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,6 +19,8 @@ jobs:
           inputs: Sources/CombineSchedulers
           module-name: CombineSchedulers
           output: Documentation
+      - name: Update Permissions
+        run: 'sudo chown --recursive $USER Documentation'
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:


### PR DESCRIPTION
Noticed this failed with the latest release. It needs the same permissions logic as our other repos.