### PR TITLE
More ergonomic Immediate/FailingSchedulers

### DIFF
--- a/Sources/CombineSchedulers/FailingScheduler.swift
+++ b/Sources/CombineSchedulers/FailingScheduler.swift
@@ -149,6 +149,58 @@
     }
   }
 
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  extension DispatchQueue {
+    /// A failing scheduler that can substitute itself for a dispatch queue.
+    public static var failing: FailingSchedulerOf<DispatchQueue> {
+      Self.failing("DispatchQueue")
+    }
+
+    /// A failing scheduler that can substitute itself for a dispatch queue.
+    ///
+    /// - Parameter prefix: A string that identifies this scheduler and will prefix all failure
+    ///   messages.
+    /// - Returns: A failing scheduler.
+    public static func failing(_ prefix: String) -> FailingSchedulerOf<DispatchQueue> {
+      // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
+      .init(prefix, now: .init(.init(uptimeNanoseconds: 1)))
+    }
+  }
+
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  extension OperationQueue {
+    /// A failing scheduler that can substitute itself for an operation queue.
+    public static var failing: FailingSchedulerOf<OperationQueue> {
+      Self.failing("OperationQueue")
+    }
+
+    /// A failing scheduler that can substitute itself for an operation queue.
+    ///
+    /// - Parameter prefix: A string that identifies this scheduler and will prefix all failure
+    ///   messages.
+    /// - Returns: A failing scheduler.
+    public static func failing(_ prefix: String) -> FailingSchedulerOf<OperationQueue> {
+      .init(prefix, now: .init(.init(timeIntervalSince1970: 0)))
+    }
+  }
+
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  extension RunLoop {
+    /// A failing scheduler that can substitute itself for a run loop.
+    public static var failing: FailingSchedulerOf<RunLoop> {
+      Self.failing("RunLoop")
+    }
+
+    /// A failing scheduler that can substitute itself for a run loop.
+    ///
+    /// - Parameter prefix: A string that identifies this scheduler and will prefix all failure
+    ///   messages.
+    /// - Returns: A failing scheduler.
+    public static func failing(_ prefix: String) -> FailingSchedulerOf<RunLoop> {
+      .init(prefix, now: .init(.init(timeIntervalSince1970: 0)))
+    }
+  }
+
   @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
   extension AnyScheduler
   where
@@ -156,26 +208,16 @@
     SchedulerOptions == DispatchQueue.SchedulerOptions
   {
     public static var failing: Self {
-      .failing("")
+      DispatchQueue.failing.eraseToAnyScheduler()
     }
 
+    /// A failing scheduler that can substitute itself for a dispatch queue.
+    ///
+    /// - Parameter prefix: A string that identifies this scheduler and will prefix all failure
+    ///   messages.
+    /// - Returns: A failing scheduler.
     public static func failing(_ prefix: String) -> Self {
       DispatchQueue.failing(prefix).eraseToAnyScheduler()
-    }
-  }
-
-  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
-  extension AnyScheduler
-  where
-    SchedulerTimeType == RunLoop.SchedulerTimeType,
-    SchedulerOptions == RunLoop.SchedulerOptions
-  {
-    public static var failing: Self {
-      .failing("")
-    }
-
-    public static func failing(_ prefix: String) -> Self {
-      RunLoop.failing(prefix).eraseToAnyScheduler()
     }
   }
 
@@ -185,46 +227,39 @@
     SchedulerTimeType == OperationQueue.SchedulerTimeType,
     SchedulerOptions == OperationQueue.SchedulerOptions
   {
+    /// A failing scheduler that can substitute itself for an operation queue.
     public static var failing: Self {
-      .failing("")
+      OperationQueue.failing.eraseToAnyScheduler()
     }
 
+    /// A failing scheduler that can substitute itself for an operation queue.
+    ///
+    /// - Parameter prefix: A string that identifies this scheduler and will prefix all failure
+    ///   messages.
+    /// - Returns: A failing scheduler.
     public static func failing(_ prefix: String) -> Self {
       OperationQueue.failing(prefix).eraseToAnyScheduler()
     }
   }
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-  extension DispatchQueue {
-    public static var failing: FailingSchedulerOf<DispatchQueue> {
-      Self.failing("")
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  extension AnyScheduler
+  where
+    SchedulerTimeType == RunLoop.SchedulerTimeType,
+    SchedulerOptions == RunLoop.SchedulerOptions
+  {
+    /// A failing scheduler that can substitute itself for a run loop.
+    public static var failing: Self {
+      RunLoop.failing.eraseToAnyScheduler()
     }
 
-    public static func failing(_ prefix: String) -> FailingSchedulerOf<DispatchQueue> {
-      // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
-      .init(prefix, now: .init(.init(uptimeNanoseconds: 1)))
-    }
-  }
-
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-  extension OperationQueue {
-    public static var failing: FailingSchedulerOf<OperationQueue> {
-      Self.failing("")
-    }
-
-    public static func failing(_ prefix: String = "") -> FailingSchedulerOf<OperationQueue> {
-      .init(prefix, now: .init(.init(timeIntervalSince1970: 0)))
-    }
-  }
-
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-  extension RunLoop {
-    public static var failing: FailingSchedulerOf<RunLoop> {
-      Self.failing("")
-    }
-
-    public static func failing(_ prefix: String = "") -> FailingSchedulerOf<RunLoop> {
-      .init(prefix, now: .init(.init(timeIntervalSince1970: 0)))
+    /// A failing scheduler that can substitute itself for a run loop.
+    ///
+    /// - Parameter prefix: A string that identifies this scheduler and will prefix all failure
+    ///   messages.
+    /// - Returns: A failing scheduler.
+    public static func failing(_ prefix: String) -> Self {
+      RunLoop.failing(prefix).eraseToAnyScheduler()
     }
   }
 

--- a/Sources/CombineSchedulers/ImmediateScheduler.swift
+++ b/Sources/CombineSchedulers/ImmediateScheduler.swift
@@ -133,36 +133,63 @@
   }
 
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-  extension Scheduler
+  extension DispatchQueue {
+    /// An immediate scheduler that can substitute itself for a dispatch queue.
+    public static var immediate: ImmediateSchedulerOf<DispatchQueue> {
+      // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
+      .init(now: .init(.init(uptimeNanoseconds: 1)))
+    }
+  }
+
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  extension OperationQueue {
+    /// An immediate scheduler that can substitute itself for an operation queue.
+    public static var immediate: ImmediateSchedulerOf<OperationQueue> {
+      .init(now: .init(.init(timeIntervalSince1970: 0)))
+    }
+  }
+
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  extension RunLoop {
+    /// An immediate scheduler that can substitute itself for a run loop.
+    public static var immediate: ImmediateSchedulerOf<RunLoop> {
+      .init(now: .init(.init(timeIntervalSince1970: 0)))
+    }
+  }
+
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  extension AnyScheduler
   where
     SchedulerTimeType == DispatchQueue.SchedulerTimeType,
     SchedulerOptions == DispatchQueue.SchedulerOptions
   {
-    public static var immediateScheduler: ImmediateSchedulerOf<Self> {
-      // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
-      ImmediateScheduler(now: SchedulerTimeType(DispatchTime(uptimeNanoseconds: 1)))
+    /// An immediate scheduler that can substitute itself for a dispatch queue.
+    public static var immediate: Self {
+      DispatchQueue.immediate.eraseToAnyScheduler()
     }
   }
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-  extension Scheduler
-  where
-    SchedulerTimeType == RunLoop.SchedulerTimeType,
-    SchedulerOptions == RunLoop.SchedulerOptions
-  {
-    public static var immediateScheduler: ImmediateSchedulerOf<Self> {
-      ImmediateScheduler(now: SchedulerTimeType(Date(timeIntervalSince1970: 0)))
-    }
-  }
-
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-  extension Scheduler
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  extension AnyScheduler
   where
     SchedulerTimeType == OperationQueue.SchedulerTimeType,
     SchedulerOptions == OperationQueue.SchedulerOptions
   {
-    public static var immediateScheduler: ImmediateSchedulerOf<Self> {
-      ImmediateScheduler(now: SchedulerTimeType(Date(timeIntervalSince1970: 0)))
+    /// An immediate scheduler that can substitute itself for an operation queue.
+    public static var immediate: Self {
+      OperationQueue.immediate.eraseToAnyScheduler()
+    }
+  }
+
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  extension AnyScheduler
+  where
+    SchedulerTimeType == RunLoop.SchedulerTimeType,
+    SchedulerOptions == RunLoop.SchedulerOptions
+  {
+    /// An immediate scheduler that can substitute itself for a run loop.
+    public static var immediate: Self {
+      RunLoop.immediate.eraseToAnyScheduler()
     }
   }
 

--- a/Sources/CombineSchedulers/Internal/Deprecations.swift
+++ b/Sources/CombineSchedulers/Internal/Deprecations.swift
@@ -1,0 +1,83 @@
+#if canImport(Combine)
+  import Combine
+  import Foundation
+
+  // To later deprecate:
+
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  extension Scheduler
+  where
+    SchedulerTimeType == DispatchQueue.SchedulerTimeType,
+    SchedulerOptions == DispatchQueue.SchedulerOptions
+  {
+//    @available(*, deprecated, renamed: "immediate")
+    public static var immediateScheduler: ImmediateSchedulerOf<Self> {
+      // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
+      ImmediateScheduler(now: SchedulerTimeType(DispatchTime(uptimeNanoseconds: 1)))
+    }
+  }
+
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  extension Scheduler
+  where
+    SchedulerTimeType == RunLoop.SchedulerTimeType,
+    SchedulerOptions == RunLoop.SchedulerOptions
+  {
+//    @available(*, deprecated, renamed: "immediate")
+    public static var immediateScheduler: ImmediateSchedulerOf<Self> {
+      ImmediateScheduler(now: SchedulerTimeType(Date(timeIntervalSince1970: 0)))
+    }
+  }
+
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  extension Scheduler
+  where
+    SchedulerTimeType == OperationQueue.SchedulerTimeType,
+    SchedulerOptions == OperationQueue.SchedulerOptions
+  {
+//    @available(*, deprecated, renamed: "immediate")
+    public static var immediateScheduler: ImmediateSchedulerOf<Self> {
+      ImmediateScheduler(now: SchedulerTimeType(Date(timeIntervalSince1970: 0)))
+    }
+  }
+
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  extension Scheduler
+  where
+    SchedulerTimeType == DispatchQueue.SchedulerTimeType,
+    SchedulerOptions == DispatchQueue.SchedulerOptions
+  {
+//    @available(*, deprecated, renamed: "test")
+    /// A test scheduler of dispatch queues.
+    public static var testScheduler: TestSchedulerOf<Self> {
+      // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
+      TestScheduler(now: SchedulerTimeType(DispatchTime(uptimeNanoseconds: 1)))
+    }
+  }
+
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  extension Scheduler
+  where
+    SchedulerTimeType == OperationQueue.SchedulerTimeType,
+    SchedulerOptions == OperationQueue.SchedulerOptions
+  {
+//    @available(*, deprecated, renamed: "test")
+    /// A test scheduler of operation queues.
+    public static var testScheduler: TestSchedulerOf<Self> {
+      TestScheduler(now: SchedulerTimeType(Date(timeIntervalSince1970: 0)))
+    }
+  }
+
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  extension Scheduler
+  where
+    SchedulerTimeType == RunLoop.SchedulerTimeType,
+    SchedulerOptions == RunLoop.SchedulerOptions
+  {
+//    @available(*, deprecated, renamed: "test")
+    /// A test scheduler of run loops.
+    public static var testScheduler: TestSchedulerOf<Self> {
+      TestScheduler(now: SchedulerTimeType(Date(timeIntervalSince1970: 0)))
+    }
+  }
+#endif

--- a/Sources/CombineSchedulers/Internal/Deprecations.swift
+++ b/Sources/CombineSchedulers/Internal/Deprecations.swift
@@ -2,7 +2,7 @@
   import Combine
   import Foundation
 
-  // To later deprecate:
+  // NB: Deprecated after 0.4.1:
 
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   extension Scheduler
@@ -10,7 +10,7 @@
     SchedulerTimeType == DispatchQueue.SchedulerTimeType,
     SchedulerOptions == DispatchQueue.SchedulerOptions
   {
-//    @available(*, deprecated, renamed: "immediate")
+    @available(*, deprecated, renamed: "immediate")
     public static var immediateScheduler: ImmediateSchedulerOf<Self> {
       // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
       ImmediateScheduler(now: SchedulerTimeType(DispatchTime(uptimeNanoseconds: 1)))
@@ -23,7 +23,7 @@
     SchedulerTimeType == RunLoop.SchedulerTimeType,
     SchedulerOptions == RunLoop.SchedulerOptions
   {
-//    @available(*, deprecated, renamed: "immediate")
+    @available(*, deprecated, renamed: "immediate")
     public static var immediateScheduler: ImmediateSchedulerOf<Self> {
       ImmediateScheduler(now: SchedulerTimeType(Date(timeIntervalSince1970: 0)))
     }
@@ -35,7 +35,7 @@
     SchedulerTimeType == OperationQueue.SchedulerTimeType,
     SchedulerOptions == OperationQueue.SchedulerOptions
   {
-//    @available(*, deprecated, renamed: "immediate")
+    @available(*, deprecated, renamed: "immediate")
     public static var immediateScheduler: ImmediateSchedulerOf<Self> {
       ImmediateScheduler(now: SchedulerTimeType(Date(timeIntervalSince1970: 0)))
     }
@@ -47,8 +47,8 @@
     SchedulerTimeType == DispatchQueue.SchedulerTimeType,
     SchedulerOptions == DispatchQueue.SchedulerOptions
   {
-//    @available(*, deprecated, renamed: "test")
     /// A test scheduler of dispatch queues.
+    @available(*, deprecated, renamed: "test")
     public static var testScheduler: TestSchedulerOf<Self> {
       // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
       TestScheduler(now: SchedulerTimeType(DispatchTime(uptimeNanoseconds: 1)))
@@ -61,8 +61,8 @@
     SchedulerTimeType == OperationQueue.SchedulerTimeType,
     SchedulerOptions == OperationQueue.SchedulerOptions
   {
-//    @available(*, deprecated, renamed: "test")
     /// A test scheduler of operation queues.
+    @available(*, deprecated, renamed: "test")
     public static var testScheduler: TestSchedulerOf<Self> {
       TestScheduler(now: SchedulerTimeType(Date(timeIntervalSince1970: 0)))
     }
@@ -74,8 +74,8 @@
     SchedulerTimeType == RunLoop.SchedulerTimeType,
     SchedulerOptions == RunLoop.SchedulerOptions
   {
-//    @available(*, deprecated, renamed: "test")
     /// A test scheduler of run loops.
+    @available(*, deprecated, renamed: "test")
     public static var testScheduler: TestSchedulerOf<Self> {
       TestScheduler(now: SchedulerTimeType(Date(timeIntervalSince1970: 0)))
     }

--- a/Sources/CombineSchedulers/TestScheduler.swift
+++ b/Sources/CombineSchedulers/TestScheduler.swift
@@ -176,40 +176,28 @@
     }
   }
 
-  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
-  extension Scheduler
-  where
-    SchedulerTimeType == DispatchQueue.SchedulerTimeType,
-    SchedulerOptions == DispatchQueue.SchedulerOptions
-  {
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  extension DispatchQueue {
     /// A test scheduler of dispatch queues.
-    public static var testScheduler: TestSchedulerOf<Self> {
+    public static var test: TestSchedulerOf<DispatchQueue> {
       // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
-      TestScheduler(now: SchedulerTimeType(DispatchTime(uptimeNanoseconds: 1)))
+      .init(now: .init(.init(uptimeNanoseconds: 1)))
     }
   }
 
-  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
-  extension Scheduler
-  where
-    SchedulerTimeType == RunLoop.SchedulerTimeType,
-    SchedulerOptions == RunLoop.SchedulerOptions
-  {
-    /// A test scheduler of run loops.
-    public static var testScheduler: TestSchedulerOf<Self> {
-      TestScheduler(now: SchedulerTimeType(Date(timeIntervalSince1970: 0)))
-    }
-  }
-
-  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
-  extension Scheduler
-  where
-    SchedulerTimeType == OperationQueue.SchedulerTimeType,
-    SchedulerOptions == OperationQueue.SchedulerOptions
-  {
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  extension OperationQueue {
     /// A test scheduler of operation queues.
-    public static var testScheduler: TestSchedulerOf<Self> {
-      TestScheduler(now: SchedulerTimeType(Date(timeIntervalSince1970: 0)))
+    public static var test: TestSchedulerOf<OperationQueue> {
+      .init(now: .init(.init(timeIntervalSince1970: 0)))
+    }
+  }
+
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  extension RunLoop {
+    /// A test scheduler of run loops.
+    public static var test: TestSchedulerOf<RunLoop> {
+      .init(now: .init(.init(timeIntervalSince1970: 0)))
     }
   }
 

--- a/Tests/CombineSchedulersTests/ImmediateSchedulerTests.swift
+++ b/Tests/CombineSchedulersTests/ImmediateSchedulerTests.swift
@@ -6,7 +6,7 @@
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   final class ImmediateSchedulerTests: XCTestCase {
     func testSchedulesImmediately() {
-      let scheduler = DispatchQueue.immediateScheduler
+      let scheduler = DispatchQueue.immediate
       var worked = 0
 
       scheduler.schedule { worked += 1 }

--- a/Tests/CombineSchedulersTests/TestSchedulerTests.swift
+++ b/Tests/CombineSchedulersTests/TestSchedulerTests.swift
@@ -8,7 +8,7 @@
     var cancellables: Set<AnyCancellable> = []
 
     func testAdvance() {
-      let scheduler = DispatchQueue.testScheduler
+      let scheduler = DispatchQueue.test
 
       var value: Int?
       Just(1)
@@ -56,7 +56,7 @@
     }
 
     func testDelay0Advance() {
-      let scheduler = DispatchQueue.testScheduler
+      let scheduler = DispatchQueue.test
 
       var value: Int?
       Just(1)
@@ -72,7 +72,7 @@
     }
 
     func testSubscribeOnAdvance() {
-      let scheduler = DispatchQueue.testScheduler
+      let scheduler = DispatchQueue.test
 
       var value: Int?
       Just(1)
@@ -88,7 +88,7 @@
     }
 
     func testReceiveOnAdvance() {
-      let scheduler = DispatchQueue.testScheduler
+      let scheduler = DispatchQueue.test
 
       var value: Int?
       Just(1)
@@ -104,7 +104,7 @@
     }
 
     func testDispatchQueueDefaults() {
-      let scheduler = DispatchQueue.testScheduler
+      let scheduler = DispatchQueue.test
       scheduler.advance(by: .nanoseconds(0))
 
       XCTAssertEqual(
@@ -118,7 +118,7 @@
     }
 
     func testTwoIntervalOrdering() {
-      let testScheduler = DispatchQueue.testScheduler
+      let testScheduler = DispatchQueue.test
 
       var values: [Int] = []
 


### PR DESCRIPTION
- Added .immediate constructor
- Added default prefixes describing failing schedulers
- Pre-deprecates .immediateScheduler and .testScheduler