### PR TITLE
feat: Remove platform bindings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,12 +4,6 @@ import PackageDescription
 
 let package = Package(
   name: "combine-schedulers",
-  platforms: [
-    .iOS(.v10),
-    .macOS(.v10_12),
-    .tvOS(.v10),
-    .watchOS(.v3),
-  ],
   products: [
     .library(
       name: "CombineSchedulers",


### PR DESCRIPTION
The package can be compiled for the lower platform versions (thanks to `@available`), so it probably shouldn't restrict users from import itself 
<img width="745" alt="Screenshot 2021-07-21 at 10 34 44" src="https://user-images.githubusercontent.com/40476363/126442468-19273f36-2316-4e0b-8633-b3f54190bfa6.png">

Users can probably use conditional imports, but it makes usage of the package as a dependency a bit more complicated, so this PR removes platform bindings