### PR TITLE
fix word from "reload" to "favorite" in README and Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ class EpisodeViewModel: ObservableObject {
 
 The API client delivers the episode on a background queue, so the view model must receive it on its main queue before mutating its state.
 
-Tapping the reload button, however, involves no scheduling. This means that a test can be written with a failing scheduler:
+Tapping the favorite button, however, involves no scheduling. This means that a test can be written with a failing scheduler:
 
 ```swift
 func testFavoriteButton() {

--- a/Sources/CombineSchedulers/FailingScheduler.swift
+++ b/Sources/CombineSchedulers/FailingScheduler.swift
@@ -43,7 +43,7 @@
   /// The API client delivers the episode on a background queue, so the view model must receive it
   /// on its main queue before mutating its state.
   ///
-  /// Tapping the reload button, however, involves no scheduling. This means that a test can be
+  /// Tapping the favorite button, however, involves no scheduling. This means that a test can be
   /// written with a failing scheduler:
   ///
   ///     func testFavoriteButton() {


### PR DESCRIPTION
Hi. Thank you for always providing such a wonderful library.

As for the word `FailingScheduler` in the README and FailingScheduler.swift, I thought it was "favorite", not "reload".
This is because the reload button involves scheduling.

So I fix that word.