### PR TITLE
Fix anchor link to UIScheduler in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A few schedulers that make working with Combine more testable and more versatile
   * [`ImmediateScheduler`](#immediatescheduler)
   * [Animated schedulers](#animated-schedulers)
   * [`FailingScheduler`](#failingscheduler)
-  * [`UIScheduler`](#testscheduler)
+  * [`UIScheduler`](#uischeduler)
   * [`Publishers.Timer`](#publisherstimer)
 * [Installation](#installation)
 * [Documentation](#documentation)


### PR DESCRIPTION
Currently `UIScheduler` in the table of contents is liked to the `TestScheduler` section.

(Yes, I noticed this bug recently when I tried to use `UIScheduler`. It's very useful!)