### PR TITLE
Add AnySchedulerOf<DispatchQueue>.global(qos:)

### DIFF
--- a/Sources/CombineSchedulers/AnyScheduler.swift
+++ b/Sources/CombineSchedulers/AnyScheduler.swift
@@ -247,6 +247,11 @@ where
   public static var main: Self {
     DispatchQueue.main.eraseToAnyScheduler()
   }
+  
+  /// A type-erased global dispatch queue with the specified quality-of-service class
+  public static func global(qos:  DispatchQoS.QoSClass = .default) -> Self {
+    DispatchQueue.global(qos: qos).eraseToAnyScheduler()
+  }
 }
 
 extension AnyScheduler


### PR DESCRIPTION
Think it's okay to add a helper for global dispatch queues?