### PR TITLE
Revert "Don't track Package.resolved (#51)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,3 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
-
-# Prevent committing Package.resolved to ensure library isn't accidentally pinned to specific dependency version
-Package.resolved

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "50a70a9d3583fe228ce672e8923010c8df2deddd",
+          "version": "0.2.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
This reverts commit 85fe09874c0e214d254b4d12138a1ad568145e71.

After encountering CI build issues in another repo, I _do_ think we want to keep this checked into the repo (and all projects, really). I haven't been able to find any documentation or evidence showing that SPM package resolution takes any downstream `Package.resolved` files into account, and can't really imagine how that would work in practice, especially if 2 dependencies depend on a compatible version of another dependency, but specify differerent versions in their `Package.resolved` files.
