### PR TITLE
Rename `FailingScheduler` to `UnimplementedScheduler`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         xcode:
-          - '13.3'
+          - '13.4.1'
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,11 @@ on:
 
 jobs:
   library:
-    runs-on: macOS-11
+    runs-on: macOS-12
     strategy:
       matrix:
         xcode:
-          - '11.7'
-          - '12.4'
-          - '12.5.1'
-          - '13.0'
+          - '13.3'
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PLATFORM_IOS = iOS Simulator,name=iPhone 11 Pro Max
 PLATFORM_MACOS = macOS
-PLATFORM_TVOS = tvOS Simulator,name=Apple TV 4K (at 1080p)
-PLATFORM_WATCHOS = watchOS Simulator,name=Apple Watch Series 4 - 44mm
+PLATFORM_TVOS = tvOS Simulator,name=Apple TV
+PLATFORM_WATCHOS = watchOS Simulator,name=Apple Watch Series 5 - 44mm
 
 test:
 	swift test --enable-test-discovery

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PLATFORM_TVOS = tvOS Simulator,name=Apple TV
 PLATFORM_WATCHOS = watchOS Simulator,name=Apple Watch Series 5 - 44mm
 
 test:
-	swift test --enable-test-discovery
+	swift test
 	xcodebuild test \
 		-scheme combine-schedulers \
 		-destination platform="$(PLATFORM_IOS)"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "50a70a9d3583fe228ce672e8923010c8df2deddd",
-          "version": "0.2.1"
+          "revision": "f821dcbac7cb6913f8e0d1a80496d0ba0199fa81",
+          "version": "0.3.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 
 import PackageDescription
 
@@ -23,13 +23,13 @@ let package = Package(
     .target(
       name: "CombineSchedulers",
       dependencies: [
-        "XCTestDynamicOverlay"
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(
       name: "CombineSchedulersTests",
       dependencies: [
-        "CombineSchedulers"
+        "CombineSchedulers",
       ]
     ),
   ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.2.1")
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.3.0")
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A few schedulers that make working with Combine more testable and more versatile
   * [`TestScheduler`](#testscheduler)
   * [`ImmediateScheduler`](#immediatescheduler)
   * [Animated schedulers](#animated-schedulers)
-  * [`FailingScheduler`](#failingscheduler)
+  * [`UnimplementedScheduler`](#unimplementedscheduler)
   * [`UIScheduler`](#uischeduler)
   * [`Publishers.Timer`](#publisherstimer)
 * [Installation](#installation)
@@ -307,13 +307,13 @@ self.apiClient.fetchEpisode()
   .assign(to: &self.$episode)
 ```
 
-### `FailingScheduler`
+### `UnimplementedScheduler`
 
 A scheduler that causes a test to fail if it is used.
 
 This scheduler can provide an additional layer of certainty that a tested code path does not require the use of a scheduler.
 
-As a view model becomes more complex, only some of its logic may require a scheduler. When writing unit tests for any logic that does _not_ require a scheduler, one should provide a failing scheduler, instead. This documents, directly in the test, that the feature does not use a scheduler. If it did, or ever does in the future, the test will fail.
+As a view model becomes more complex, only some of its logic may require a scheduler. When writing unit tests for any logic that does _not_ require a scheduler, one should provide an unimplemented scheduler, instead. This documents, directly in the test, that the feature does not use a scheduler. If it did, or ever does in the future, the test will fail.
 
 For example, the following view model has a couple responsibilities:
 
@@ -346,13 +346,13 @@ class EpisodeViewModel: ObservableObject {
 
 The API client delivers the episode on a background queue, so the view model must receive it on its main queue before mutating its state.
 
-Tapping the favorite button, however, involves no scheduling. This means that a test can be written with a failing scheduler:
+Tapping the favorite button, however, involves no scheduling. This means that a test can be written with an unimplemented scheduler:
 
 ```swift
 func testFavoriteButton() {
   let viewModel = EpisodeViewModel(
     apiClient: .mock,
-    mainQueue: .failing
+    mainQueue: .unimplemented
   )
   viewModel.episode = .mock
 
@@ -364,7 +364,7 @@ func testFavoriteButton() {
 }
 ```
 
-With `.failing`, this test strongly declares that favoriting an episode does not need a scheduler to do the job, which means it is reasonable to assume that the feature is simple and does not involve any asynchrony.
+With `.unimplemented`, this test strongly declares that favoriting an episode does not need a scheduler to do the job, which means it is reasonable to assume that the feature is simple and does not involve any asynchrony.
 
 In the future, should favoriting an episode fire off an API request that involves a scheduler, this test will begin to fail, which is a good thing! This will force us to address the complexity that was introduced. Had we used any other scheduler, it would quietly receive this additional work and the test would continue to pass.
 

--- a/Sources/CombineSchedulers/AnyScheduler.swift
+++ b/Sources/CombineSchedulers/AnyScheduler.swift
@@ -9,21 +9,23 @@ import Foundation
 /// example, suppose you have a view model `ObservableObject` that performs an API request when a
 /// method is called:
 ///
-///     class EpisodeViewModel: ObservableObject {
-///       @Published var episode: Episode?
+/// ```swift
+/// class EpisodeViewModel: ObservableObject {
+///   @Published var episode: Episode?
 ///
-///       let apiClient: ApiClient
+///   let apiClient: ApiClient
 ///
-///       init(apiClient: ApiClient) {
-///         self.apiClient = apiClient
-///       }
+///   init(apiClient: ApiClient) {
+///     self.apiClient = apiClient
+///   }
 ///
-///       func reloadButtonTapped() {
-///         self.apiClient.fetchEpisode()
-///           .receive(on: DispatchQueue.main)
-///           .assign(to: &self.$episode)
-///       }
-///     }
+///   func reloadButtonTapped() {
+///     self.apiClient.fetchEpisode()
+///       .receive(on: DispatchQueue.main)
+///       .assign(to: &self.$episode)
+///   }
+/// }
+/// ```
 ///
 /// Notice that we are using `DispatchQueue.main` in the `reloadButtonTapped` method because the
 /// `fetchEpisode` endpoint most likely delivers its output on a background thread (as is the case
@@ -39,23 +41,25 @@ import Foundation
 /// with no thread hops. In order to allow for this we would need to inject a scheduler into our
 /// view model so that we can control it from the outside:
 ///
-///     class EpisodeViewModel<S: Scheduler>: ObservableObject {
-///       @Published var episode: Episode?
+/// ```swift
+/// class EpisodeViewModel<S: Scheduler>: ObservableObject {
+///   @Published var episode: Episode?
 ///
-///       let apiClient: ApiClient
-///       let scheduler: S
+///   let apiClient: ApiClient
+///   let scheduler: S
 ///
-///       init(apiClient: ApiClient, scheduler: S) {
-///         self.apiClient = apiClient
-///         self.scheduler = scheduler
-///       }
+///   init(apiClient: ApiClient, scheduler: S) {
+///     self.apiClient = apiClient
+///     self.scheduler = scheduler
+///   }
 ///
-///       func reloadButtonTapped() {
-///         self.apiClient.fetchEpisode()
-///           .receive(on: self.scheduler)
-///           .assign(to: &self.$episode)
-///       }
-///     }
+///   func reloadButtonTapped() {
+///     self.apiClient.fetchEpisode()
+///       .receive(on: self.scheduler)
+///       .assign(to: &self.$episode)
+///   }
+/// }
+/// ```
 ///
 /// Now we can initialize this view model in production by using `DispatchQueue.main` and we can
 /// initialize it in tests using `DispatchQueue.immediate`. Sounds like a win!
@@ -73,46 +77,54 @@ import Foundation
 /// Instead of holding a generic scheduler in our view model we can say that we only want a
 /// scheduler whose associated types match that of `DispatchQueue`:
 ///
-///     class EpisodeViewModel: ObservableObject {
-///       @Published var episode: Episode?
+/// ```swift
+/// class EpisodeViewModel: ObservableObject {
+///   @Published var episode: Episode?
 ///
-///       let apiClient: ApiClient
-///       let scheduler: AnySchedulerOf<DispatchQueue>
+///   let apiClient: ApiClient
+///   let scheduler: AnySchedulerOf<DispatchQueue>
 ///
-///       init(apiClient: ApiClient, scheduler: AnySchedulerOf<DispatchQueue>) {
-///         self.apiClient = apiClient
-///         self.scheduler = scheduler
-///       }
+///   init(apiClient: ApiClient, scheduler: AnySchedulerOf<DispatchQueue>) {
+///     self.apiClient = apiClient
+///     self.scheduler = scheduler
+///   }
 ///
-///       func reloadButtonTapped() {
-///         self.apiClient.fetchEpisode()
-///           .receive(on: self.scheduler)
-///           .assign(to: &self.$episode)
-///       }
-///     }
+///   func reloadButtonTapped() {
+///     self.apiClient.fetchEpisode()
+///       .receive(on: self.scheduler)
+///       .assign(to: &self.$episode)
+///   }
+/// }
+/// ```
 ///
 /// Then, in production we can create a view model that uses a live `DispatchQueue`, but we just
 /// have to first erase its type:
 ///
-///     let viewModel = EpisodeViewModel(
-///       apiClient: ...,
-///       scheduler: DispatchQueue.main.eraseToAnyScheduler()
-///     )
+/// ```swift
+/// let viewModel = EpisodeViewModel(
+///   apiClient: ...,
+///   scheduler: DispatchQueue.main.eraseToAnyScheduler()
+/// )
+/// ```
 ///
 /// For common schedulers, like `DispatchQueue`, `OperationQueue`, and `RunLoop`, there is even a
 /// static helper on `AnyScheduler` that further simplifies this:
 ///
-///     let viewModel = EpisodeViewModel(
-///       apiClient: ...,
-///       scheduler: .main
-///     )
+/// ```swift
+/// let viewModel = EpisodeViewModel(
+///   apiClient: ...,
+///   scheduler: .main
+/// )
+/// ```
 ///
 /// And in tests we can use an immediate scheduler:
 ///
-///     let viewModel = EpisodeViewModel(
-///       apiClient: ...,
-///       scheduler: .immediate
-///     )
+/// ```swift
+/// let viewModel = EpisodeViewModel(
+///   apiClient: ...,
+///   scheduler: .immediate
+/// )
+/// ```
 ///
 /// So, in general, `AnyScheduler` is great for allowing one to control what scheduler is used
 /// in classes, functions, etc. without needing to introduce a generic, which can help simplify

--- a/Sources/CombineSchedulers/ImmediateScheduler.swift
+++ b/Sources/CombineSchedulers/ImmediateScheduler.swift
@@ -17,77 +17,85 @@ import Foundation
 /// As a basic example, suppose you have a view model that loads some data after waiting for 10
 /// seconds from when a button is tapped:
 ///
-///     class HomeViewModel: ObservableObject {
-///       @Published var episodes: [Episode]?
+/// ```swift
+/// class HomeViewModel: ObservableObject {
+///   @Published var episodes: [Episode]?
 ///
-///       let apiClient: ApiClient
+///   let apiClient: ApiClient
 ///
-///       init(apiClient: ApiClient) {
-///         self.apiClient = apiClient
-///       }
+///   init(apiClient: ApiClient) {
+///     self.apiClient = apiClient
+///   }
 ///
-///       func reloadButtonTapped() {
-///         Just(())
-///           .delay(for: .seconds(10), scheduler: DispatchQueue.main)
-///           .flatMap { apiClient.fetchEpisodes() }
-///           .assign(to: &self.episodes)
-///       }
-///     }
+///   func reloadButtonTapped() {
+///     Just(())
+///       .delay(for: .seconds(10), scheduler: DispatchQueue.main)
+///       .flatMap { apiClient.fetchEpisodes() }
+///       .assign(to: &self.episodes)
+///   }
+/// }
+/// ```
 ///
 /// In order to test this code you would literally need to wait 10 seconds for the publisher to
 /// emit:
 ///
-///     func testViewModel() {
-///       let viewModel = HomeViewModel(apiClient: .mock)
+/// ```swift
+/// func testViewModel() {
+///   let viewModel = HomeViewModel(apiClient: .mock)
 ///
-///       viewModel.reloadButtonTapped()
+///   viewModel.reloadButtonTapped()
 ///
-///       _ = XCTWaiter.wait(for: [XCTestExpectation()], timeout: 10)
+///   _ = XCTWaiter.wait(for: [XCTestExpectation()], timeout: 10)
 ///
-///       XCTAssert(viewModel.episodes, [Episode(id: 42)])
-///     }
+///   XCTAssert(viewModel.episodes, [Episode(id: 42)])
+/// }
+/// ```
 ///
 /// Alternatively, we can explicitly pass a scheduler into the view model initializer so that it
 /// can be controller from the outside:
 ///
-///     class HomeViewModel: ObservableObject {
-///       @Published var episodes: [Episode]?
+/// ```swift
+/// class HomeViewModel: ObservableObject {
+///   @Published var episodes: [Episode]?
 ///
-///       let apiClient: ApiClient
-///       let scheduler: AnySchedulerOf<DispatchQueue>
+///   let apiClient: ApiClient
+///   let scheduler: AnySchedulerOf<DispatchQueue>
 ///
-///       init(apiClient: ApiClient, scheduler: AnySchedulerOf<DispatchQueue>) {
-///         self.apiClient = apiClient
-///         self.scheduler = scheduler
-///       }
+///   init(apiClient: ApiClient, scheduler: AnySchedulerOf<DispatchQueue>) {
+///     self.apiClient = apiClient
+///     self.scheduler = scheduler
+///   }
 ///
-///       func reloadButtonTapped() {
-///         Just(())
-///           .delay(for: .seconds(10), scheduler: self.scheduler)
-///           .flatMap { self.apiClient.fetchEpisodes() }
-///           .assign(to: &self.$episodes)
-///       }
-///     }
+///   func reloadButtonTapped() {
+///     Just(())
+///       .delay(for: .seconds(10), scheduler: self.scheduler)
+///       .flatMap { self.apiClient.fetchEpisodes() }
+///       .assign(to: &self.$episodes)
+///   }
+/// }
+/// ```
 ///
 /// And then in tests use an immediate scheduler:
 ///
-///     func testViewModel() {
-///       let viewModel = HomeViewModel(
-///         apiClient: .mock,
-///         scheduler: .immediate
-///       )
+/// ```swift
+/// func testViewModel() {
+///   let viewModel = HomeViewModel(
+///     apiClient: .mock,
+///     scheduler: .immediate
+///   )
 ///
-///       viewModel.reloadButtonTapped()
+///   viewModel.reloadButtonTapped()
 ///
-///       // No more waiting...
+///   // No more waiting...
 ///
-///       XCTAssert(viewModel.episodes, [Episode(id: 42)])
-///     }
+///   XCTAssert(viewModel.episodes, [Episode(id: 42)])
+/// }
+/// ```
 ///
-/// - Note: This scheduler can _not_ be used to test publishers with more complex timing logic,
-///   like those that use `Debounce`, `Throttle`, or `Timer.Publisher`, and in fact
-///   `ImmediateScheduler` will not schedule this work in a defined way. Use a `TestScheduler`
-///   instead to capture your publisher's timing behavior.
+/// > Note: This scheduler can _not_ be used to test publishers with more complex timing logic,
+/// > like those that use `Debounce`, `Throttle`, or `Timer.Publisher`, and in fact
+/// > `ImmediateScheduler` will not schedule this work in a defined way. Use a `TestScheduler`
+/// > instead to capture your publisher's timing behavior.
 ///
 public struct ImmediateScheduler<SchedulerTimeType, SchedulerOptions>: Scheduler
 where

--- a/Sources/CombineSchedulers/Internal/Deprecations.swift
+++ b/Sources/CombineSchedulers/Internal/Deprecations.swift
@@ -1,6 +1,122 @@
 import Combine
 import Foundation
 
+// NB: Soft-deprecated after 0.5.3:
+
+@available(iOS, deprecated: 9999.0, renamed: "UnimplementedScheduler")
+@available(macOS, deprecated: 9999.0, renamed: "UnimplementedScheduler")
+@available(tvOS, deprecated: 9999.0, renamed: "UnimplementedScheduler")
+@available(watchOS, deprecated: 9999.0, renamed: "UnimplementedScheduler")
+public typealias FailingScheduler = UnimplementedScheduler
+
+@available(iOS, deprecated: 9999.0, renamed: "UnimplementedSchedulerOf")
+@available(macOS, deprecated: 9999.0, renamed: "UnimplementedSchedulerOf")
+@available(tvOS, deprecated: 9999.0, renamed: "UnimplementedSchedulerOf")
+@available(watchOS, deprecated: 9999.0, renamed: "UnimplementedSchedulerOf")
+public typealias FailingSchedulerOf = UnimplementedSchedulerOf
+
+extension DispatchQueue {
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static var failing: UnimplementedSchedulerOf<DispatchQueue> { Self.unimplemented }
+
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static func failing(_ prefix: String) -> UnimplementedSchedulerOf<DispatchQueue> {
+    Self.unimplemented(prefix)
+  }
+}
+
+extension OperationQueue {
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static var failing: UnimplementedSchedulerOf<OperationQueue> { Self.unimplemented }
+
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static func failing(_ prefix: String) -> UnimplementedSchedulerOf<OperationQueue> {
+    Self.unimplemented(prefix)
+  }
+}
+
+extension RunLoop {
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static var failing: UnimplementedSchedulerOf<RunLoop> { Self.unimplemented }
+
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static func failing(_ prefix: String) -> UnimplementedSchedulerOf<RunLoop> {
+    Self.unimplemented(prefix)
+  }
+}
+
+extension AnyScheduler
+where
+  SchedulerTimeType == DispatchQueue.SchedulerTimeType,
+  SchedulerOptions == DispatchQueue.SchedulerOptions
+{
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static var failing: Self { Self.unimplemented }
+
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static func failing(_ prefix: String) -> Self { Self.unimplemented(prefix) }
+}
+
+extension AnyScheduler
+where
+  SchedulerTimeType == OperationQueue.SchedulerTimeType,
+  SchedulerOptions == OperationQueue.SchedulerOptions
+{
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static var failing: Self { Self.unimplemented }
+
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static func failing(_ prefix: String) -> Self { Self.unimplemented(prefix) }
+}
+
+extension AnyScheduler
+where
+  SchedulerTimeType == RunLoop.SchedulerTimeType,
+  SchedulerOptions == RunLoop.SchedulerOptions
+{
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static var failing: Self { Self.unimplemented }
+
+  @available(iOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(macOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(tvOS, deprecated: 9999.0, renamed: "unimplemented")
+  @available(watchOS, deprecated: 9999.0, renamed: "unimplemented")
+  public static func failing(_ prefix: String) -> Self { Self.unimplemented(prefix) }
+}
+
 // NB: Deprecated after 0.4.1:
 
 extension Scheduler

--- a/Sources/CombineSchedulers/SwiftUI.swift
+++ b/Sources/CombineSchedulers/SwiftUI.swift
@@ -9,49 +9,55 @@ extension Scheduler {
   /// pipe its output into a `@Published` field, you may be tempted to use the `.assign(to:)`
   /// operator:
   ///
-  ///     class ViewModel: ObservableObject {
-  ///       @Published var articles: [Article] = []
+  /// ```swift
+  /// class ViewModel: ObservableObject {
+  ///   @Published var articles: [Article] = []
   ///
-  ///       init() {
-  ///         apiClient.loadArticles()
-  ///           .receive(on: DispatchQueue.main)
-  ///           .assign(to: &self.$articles)
-  ///       }
-  ///     }
+  ///   init() {
+  ///     apiClient.loadArticles()
+  ///       .receive(on: DispatchQueue.main)
+  ///       .assign(to: &self.$articles)
+  ///   }
+  /// }
+  /// ```
   ///
   /// However, this prevents you from wrapping the `articles` mutation in `withAnimation` since
   /// that is hidden from you in the `.assign(to:)` operator. In this situation you can simply
   /// use the `.animation` operator on `Scheduler` to transform `DispatchQueue.main` into a
   /// scheduler that performs its work inside `withAnimation`:
   ///
-  ///     class ViewModel: ObservableObject {
-  ///       @Published var articles: [Article] = []
+  /// ```swift
+  /// class ViewModel: ObservableObject {
+  ///   @Published var articles: [Article] = []
   ///
-  ///       init() {
-  ///         apiClient.loadArticles()
-  ///           .receive(on: DispatchQueue.main.animation())
-  ///           .assign(to: &self.$articles)
-  ///       }
-  ///     }
+  ///   init() {
+  ///     apiClient.loadArticles()
+  ///       .receive(on: DispatchQueue.main.animation())
+  ///       .assign(to: &self.$articles)
+  ///   }
+  /// }
+  /// ```
   ///
   /// Another common use case is when you have a Combine publisher made up of many publishers
   /// that have been merged or concatenated. You may want to animate the outputs of each of
   /// those publishers differently:
   ///
-  ///     class ViewModel: ObservableObject {
-  ///       @Published var articles: [Article] = []
+  /// ```swift
+  /// class ViewModel: ObservableObject {
+  ///   @Published var articles: [Article] = []
   ///
-  ///       init() {
-  ///         cachedArticles()
-  ///           // Don't animate cached articles when they load
-  ///           .receive(on: DispatchQueue.main.animation(nil))
-  ///           .append(
-  ///             apiClient.loadArticles()
-  ///               // Animate the fresh articles when they load
-  ///               .receive(on: DispatchQueue.main.animation())
-  ///           )
-  ///       }
-  ///     }
+  ///   init() {
+  ///     cachedArticles()
+  ///       // Don't animate cached articles when they load
+  ///       .receive(on: DispatchQueue.main.animation(nil))
+  ///       .append(
+  ///         apiClient.loadArticles()
+  ///           // Animate the fresh articles when they load
+  ///           .receive(on: DispatchQueue.main.animation())
+  ///       )
+  ///   }
+  /// }
+  /// ```
   ///
   /// - Parameter animation: An animation to be performed.
   /// - Returns: A scheduler that performs an animation when a scheduled action is run.

--- a/Sources/CombineSchedulers/TestScheduler.swift
+++ b/Sources/CombineSchedulers/TestScheduler.swift
@@ -10,46 +10,56 @@ import Foundation
 /// For example, consider the following `race` operator that runs two futures in parallel, but
 /// only emits the first one that completes:
 ///
-///     func race<Output, Failure: Error>(
-///       _ first: Future<Output, Failure>,
-///       _ second: Future<Output, Failure>
-///     ) -> AnyPublisher<Output, Failure> {
-///       first
-///         .merge(with: second)
-///         .prefix(1)
-///         .eraseToAnyPublisher()
-///     }
+/// ```swift
+/// func race<Output, Failure: Error>(
+///   _ first: Future<Output, Failure>,
+///   _ second: Future<Output, Failure>
+/// ) -> AnyPublisher<Output, Failure> {
+///   first
+///     .merge(with: second)
+///     .prefix(1)
+///     .eraseToAnyPublisher()
+/// }
+/// ```
 ///
 /// Although this publisher is quite simple we may still want to write some tests for it.
 ///
 /// To do this we can create a test scheduler and create two futures, one that emits after a
 /// second and one that emits after two seconds:
 ///
-///     let scheduler = DispatchQueue.test
-///     let first = Future<Int, Never> { callback in
-///       scheduler.schedule(after: scheduler.now.advanced(by: 1)) { callback(.success(1)) }
-///     }
-///     let second = Future<Int, Never> { callback in
-///       scheduler.schedule(after: scheduler.now.advanced(by: 2)) { callback(.success(2)) }
-///     }
+/// ```swift
+/// let scheduler = DispatchQueue.test
+/// let first = Future<Int, Never> { callback in
+///   scheduler.schedule(after: scheduler.now.advanced(by: 1)) { callback(.success(1)) }
+/// }
+/// let second = Future<Int, Never> { callback in
+///   scheduler.schedule(after: scheduler.now.advanced(by: 2)) { callback(.success(2)) }
+/// }
+/// ```
 ///
 /// And then we can race these futures and collect their emissions into an array:
 ///
-///     var output: [Int] = []
-///     let cancellable = race(first, second).sink { output.append($0) }
+/// ```swift
+/// var output: [Int] = []
+/// let cancellable = race(first, second).sink { output.append($0) }
+/// ```
 ///
 /// And then we can deterministically move time forward in the scheduler to see how the publisher
 /// emits. We can start by moving time forward by one second:
 ///
-///     scheduler.advance(by: 1)
-///     XCTAssertEqual(output, [1])
+/// ```swift
+/// scheduler.advance(by: 1)
+/// XCTAssertEqual(output, [1])
+/// ```
 ///
 /// This proves that we get the first emission from the publisher since one second of time has
 /// passed. If we further advance by one more second we can prove that we do not get anymore
 /// emissions:
 ///
-///     scheduler.advance(by: 1)
-///     XCTAssertEqual(output, [1])
+/// ```swift
+/// scheduler.advance(by: 1)
+/// XCTAssertEqual(output, [1])
+/// ```
 ///
 /// This is a very simple example of how to control the flow of time with the test scheduler,
 /// but this technique can be used to test any publisher that involves Combine's asynchronous

--- a/Sources/CombineSchedulers/UnimplementedScheduler.swift
+++ b/Sources/CombineSchedulers/UnimplementedScheduler.swift
@@ -47,19 +47,21 @@ import XCTestDynamicOverlay
 /// Tapping the favorite button, however, involves no scheduling. This means that a test can be
 /// written with an unimplemented scheduler:
 ///
-///     func testFavoriteButton() {
-///       let viewModel = EpisodeViewModel(
-///         apiClient: .mock,
-///         mainQueue: .unimplemented
-///       )
-///       viewModel.episode = .mock
+/// ```swift
+/// func testFavoriteButton() {
+///   let viewModel = EpisodeViewModel(
+///     apiClient: .mock,
+///     mainQueue: .unimplemented
+///   )
+///   viewModel.episode = .mock
 ///
-///       viewModel.favoriteButtonTapped()
-///       XCTAssert(viewModel.episode?.isFavorite == true)
+///   viewModel.favoriteButtonTapped()
+///   XCTAssert(viewModel.episode?.isFavorite == true)
 ///
-///       viewModel.favoriteButtonTapped()
-///       XCTAssert(viewModel.episode?.isFavorite == false)
-///     }
+///   viewModel.favoriteButtonTapped()
+///   XCTAssert(viewModel.episode?.isFavorite == false)
+/// }
+/// ```
 ///
 /// With `.unimplemented`, this test pretty strongly declares that favoriting an episode does not
 /// need a scheduler to do the job, which means it is reasonable to assume that the feature is

--- a/Tests/CombineSchedulersTests/UnimplementedSchedulerTests.swift
+++ b/Tests/CombineSchedulersTests/UnimplementedSchedulerTests.swift
@@ -3,9 +3,9 @@
   import CombineSchedulers
   import XCTest
 
-  final class FailingSchedulerTests: XCTestCase {
+  final class UnimplementedSchedulerTests: XCTestCase {
     func testFailure() {
-      let scheduler = RunLoop.failing
+      let scheduler = RunLoop.unimplemented
 
       XCTExpectFailure { _ = scheduler.now }
       XCTExpectFailure { _ = scheduler.minimumTolerance }


### PR DESCRIPTION
We'll leave `FailingScheduler` in a soft-deprecated state, for now.