### PR TITLE
Remove the SchedulerOf typealias.

### DIFF
--- a/Sources/CombineSchedulers/AnyScheduler.swift
+++ b/Sources/CombineSchedulers/AnyScheduler.swift
@@ -5,21 +5,6 @@
   /// A type-erasing wrapper for the `Scheduler` protocol, which can be useful for being generic over
   /// many types of schedulers without needing to actually introduce a generic to your code.
   ///
-  /// > Important: This type is considered "soft" deprecated as of iOS 16 and Swift 5.7. Any place you
-  /// > currently use:
-  /// >
-  /// > ```swift
-  /// > let mainQueue: AnySchedulerOf<DispatchQueue>
-  /// > ```
-  /// >
-  /// > …you can now use:
-  /// >
-  /// > ```swift
-  /// > let mainQueue: any SchedulerOf<DispatchQueue>
-  /// > ```
-  /// >
-  /// > Someday in the future it will be officially deprecated and later removed.
-  ///
   /// This type is useful for times that you want to be able to customize the scheduler used in some
   /// code from the outside, but you don't want to introduce a generic to make it customizable. For
   /// example, suppose you have a view model `ObservableObject` that performs an API request when a
@@ -303,34 +288,4 @@
       RunLoop.main.eraseToAnyScheduler()
     }
   }
-
-  #if swift(>=5.7)
-    /// A convenience to specify a scheduler with the same `SchedulerTimeType` as a concrete scheduler.
-    ///
-    /// This is most useful for injecting a scheduler into some code, such as a SwiftUI
-    /// `ObservableObject`, or [Composable Architecture][tca-gh] environment. For example, a view model
-    /// that needs time-based scheduling can accept an `any SchedulerOf` as a parameter and then use
-    /// the scheduler to sleep for a duration of time:
-    ///
-    /// ```swift
-    /// class ViewModel: ObservableObject {
-    ///   @Published var message: String?
-    ///
-    ///   let mainQueue: any SchedulerOf<DispatchQueue>
-    ///   init(mainQueue: any SchedulerOf<DispatchQueue>) {
-    ///     self.mainQueue = mainQueue
-    ///   }
-    ///
-    ///   func onAppear() {
-    ///     Task {
-    ///       try await self.mainQueue.sleep(for: .seconds(1))
-    ///       self.message = "Welcome!
-    ///     }
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// [tca-gh]: http://github.com/pointfreeco/swift-composable-architecture
-    public typealias SchedulerOf<S: Scheduler> = Scheduler<S.SchedulerTimeType>
-  #endif
 #endif


### PR DESCRIPTION
Due to some bugs in Xcode and/or Swift, we are seeing the compiler/editor completely break when compiling `SchedulerOf`, and more generally, any generic typealias to a protocol with primary associated types (see this [discussion](https://github.com/pointfreeco/swift-composable-architecture/discussions/1264)).

So, we are going to remove `SchedulerOf` for now. 

Also, it turns out this typealias isn't super useful since there seems to still be a few limitations to Swift's automatic existential opening:

```swift
func existential() {
  let mainQueue: any SchedulerOf<DispatchQueue> = DispatchQueue.main

  Just(1).debounce(for: .seconds(1), scheduler: mainQueue)
  // 🛑 Type 'any SchedulerOf<DispatchQueue>' (aka 'any Scheduler<DispatchQueue.SchedulerTimeType>') 
  //    cannot conform to 'Scheduler'
}
```

We've opened a [forum post](https://forums.swift.org/t/limitation-of-implicitly-opening-existentials/59672) to see if this is a known limitation or something that could be fixed in the future.