### PR TITLE
Syntactic sugar for UI scheduler and Test scheduler erasable to UI scheduler

### DIFF
--- a/Sources/CombineSchedulers/AnyScheduler.swift
+++ b/Sources/CombineSchedulers/AnyScheduler.swift
@@ -288,4 +288,19 @@
       RunLoop.main.eraseToAnyScheduler()
     }
   }
+
+  extension AnyScheduler
+  where
+    SchedulerTimeType == DispatchQueue.SchedulerTimeType,
+    SchedulerOptions == Never
+  {
+    /// The type-erased UI scheduler shared instance.
+    ///
+    /// The UI scheduler is a scheduler that executes its work on the main
+    /// queue as soon as possible (avoiding unnecessary thread hops). See
+    /// `UIScheduler` for more information.
+    public static var ui: Self {
+      UIScheduler.shared.eraseToAnyScheduler()
+    }
+  }
 #endif

--- a/Sources/CombineSchedulers/AnyScheduler.swift
+++ b/Sources/CombineSchedulers/AnyScheduler.swift
@@ -299,7 +299,7 @@
     /// The UI scheduler is a scheduler that executes its work on the main
     /// queue as soon as possible (avoiding unnecessary thread hops). See
     /// `UIScheduler` for more information.
-    public static var ui: Self {
+    public static var shared: Self {
       UIScheduler.shared.eraseToAnyScheduler()
     }
   }

--- a/Sources/CombineSchedulers/TestScheduler.swift
+++ b/Sources/CombineSchedulers/TestScheduler.swift
@@ -257,9 +257,11 @@
       // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
       .init(now: .init(.init(uptimeNanoseconds: 1)))
     }
-
+  }
+  
+  extension UIScheduler {
     /// A test scheduler compatible with type erased UI schedulers.
-    public static var uiTest: TestScheduler<DispatchQueue.SchedulerTimeType, Never> {
+    public static var test: TestSchedulerOf<Self> {
       // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
       .init(now: .init(.init(uptimeNanoseconds: 1)))
     }

--- a/Sources/CombineSchedulers/TestScheduler.swift
+++ b/Sources/CombineSchedulers/TestScheduler.swift
@@ -257,6 +257,12 @@
       // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
       .init(now: .init(.init(uptimeNanoseconds: 1)))
     }
+
+    /// A test scheduler compatible with type erased UI schedulers.
+    public static var uiTest: TestScheduler<DispatchQueue.SchedulerTimeType, Never> {
+      // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
+      .init(now: .init(.init(uptimeNanoseconds: 1)))
+    }
   }
 
   extension OperationQueue {


### PR DESCRIPTION
Note: UIScheduler has different specialization than AnySchedulerOf, which means UIScheduler.eraseToAnyScheduler() is not compatible with AnySchedulerOf<DispatchQueue>. Likewise, the existing DispatchQueue.test.eraseToAnyScheduler() is not compatible with TestSchedulerOf<DispatchQueue>.