### PR TITLE
Make UnimplementedScheduler behave like ImmediateScheduler.

### DIFF
--- a/Sources/CombineSchedulers/UnimplementedScheduler.swift
+++ b/Sources/CombineSchedulers/UnimplementedScheduler.swift
@@ -118,6 +118,7 @@
         An unimplemented scheduler scheduled an action to run immediately.
         """
       )
+      action()
     }
 
     public func schedule(
@@ -132,6 +133,7 @@
         An unimplemented scheduler scheduled an action to run later.
         """
       )
+      action()
     }
 
     public func schedule(
@@ -147,6 +149,7 @@
         An unimplemented scheduler scheduled an action to run on a timer.
         """
       )
+      action()
       return AnyCancellable {}
     }
   }

--- a/Tests/CombineSchedulersTests/TestSchedulerTests.swift
+++ b/Tests/CombineSchedulersTests/TestSchedulerTests.swift
@@ -235,4 +235,18 @@ final class CombineSchedulerTests: XCTestCase {
     let count = await task.value
     XCTAssertEqual(count, 10)
   }
+
+  func testNowIsAdvanced() {
+    let testScheduler = DispatchQueue.test
+    let start = testScheduler.now
+
+    testScheduler.advance(by: .seconds(1))
+    XCTAssertEqual(testScheduler.now, start.advanced(by: .seconds(1)))
+
+    testScheduler.advance()
+    XCTAssertEqual(testScheduler.now, start.advanced(by: .seconds(1)))
+
+    testScheduler.advance(by: .seconds(1))
+    XCTAssertEqual(testScheduler.now, start.advanced(by: .seconds(2)))
+  }
 }

--- a/Tests/CombineSchedulersTests/UnimplementedSchedulerTests.swift
+++ b/Tests/CombineSchedulersTests/UnimplementedSchedulerTests.swift
@@ -9,12 +9,26 @@
 
       XCTExpectFailure { _ = scheduler.now }
       XCTExpectFailure { _ = scheduler.minimumTolerance }
-      XCTExpectFailure { scheduler.schedule(options: nil) {} }
       XCTExpectFailure {
-        scheduler.schedule(after: .init(.init()), tolerance: .zero, options: nil) {}
+        let expectation = self.expectation(description: "schedule")
+        scheduler.schedule(options: nil) {
+          expectation.fulfill()
+        }
+        self.wait(for: [expectation], timeout: 0.1)
       }
-      _ = XCTExpectFailure {
-        scheduler.schedule(after: .init(.init()), interval: 1, tolerance: .zero, options: nil) {}
+      XCTExpectFailure {
+        let expectation = self.expectation(description: "schedule")
+        scheduler.schedule(after: .init(.init()), tolerance: .zero, options: nil) {
+          expectation.fulfill()
+        }
+        self.wait(for: [expectation], timeout: 0.1)
+      }
+      XCTExpectFailure {
+        let expectation = self.expectation(description: "schedule")
+        _ = scheduler.schedule(after: .init(.init()), interval: 1, tolerance: .zero, options: nil) {
+          expectation.fulfill()
+        }
+        self.wait(for: [expectation], timeout: 0.1)
       }
     }
   }


### PR DESCRIPTION
The discussion in https://github.com/pointfreeco/swift-composable-architecture/discussions/1583 made me realize we should probably have `UnimplementedScheduler` actually execute its work. That way a UI test running in a test context can actually executed scheduled work.

And beyond that, the `UnimplementedClock` in swift-clocks behaves exactly like `ImmediateClock` (with the addition of doing `XCTFail`), so maybe we should align the two libraries on this.