### PR TITLE
Run `TestScheduler.advance(to:)` on the main actor

### DIFF
--- a/Sources/CombineSchedulers/TestScheduler.swift
+++ b/Sources/CombineSchedulers/TestScheduler.swift
@@ -129,6 +129,7 @@
     /// Advances the scheduler to the given instant.
     ///
     /// - Parameter instant: An instant in time to advance to.
+    @MainActor
     public func advance(to instant: SchedulerTimeType) async {
       while self.lock.sync(operation: { self.now }) <= instant {
         await Task.megaYield()


### PR DESCRIPTION
This was always an oversight, but because implementations of `to:` and `by:` flipped recently, where `by:` now calls `to:`, it becomes more of a problem area due to Swift concurrency's test unreliability.