### PR TITLE
Add possibility to configure yield count

### DIFF
--- a/Sources/CombineSchedulers/TestScheduler.swift
+++ b/Sources/CombineSchedulers/TestScheduler.swift
@@ -285,8 +285,9 @@
   > where Scheduler: Combine.Scheduler
 
   extension Task where Success == Failure, Failure == Never {
-    static func megaYield(count: Int = 10) async {
-      for _ in 1...count {
+    @TaskLocal public static var yieldCount = 10
+    static func megaYield() async {
+      for _ in 1...yieldCount {
         await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value
       }
     }


### PR DESCRIPTION
Currently the yield count in the library  is set to 10. Sometimes it might be that yielding 10 times is not enough, particular if one tests code that uses concurrency a lot.

With this change, the yield count can be configured from users of the library, which might be helpful sometimes.

In the app I am working on we have to increase the yield count from 10 to 20 to get tests passing reliably. 
I know that this is more of an issue of testing concurrency code in swift in general, but I think it would be nice to have that possibility.