### PR TITLE
Fix Swift 5.8 Library Evolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,24 @@ on:
       - '*'
 
 jobs:
-  library:
-    runs-on: macOS-12
-    strategy:
-      matrix:
-        xcode:
-          - '13.4.1'
+  library-swift-latest:
+    name: Library (swift-latest)
+    runs-on: macOS-13
     steps:
-      - uses: actions/checkout@v2
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - uses: actions/checkout@v3
+      - name: Select Xcode 14.3
+        run: sudo xcode-select -s /Applications/Xcode_14.3.app
+      - name: Run tests
+        run: make test
+      - name: Build for library evolution
+        run: make build-for-library-evolution
+
+  library-swift-5-6:
+    name: Library (swift-5.6)
+    runs-on: macOS-12
+    steps:
+      - uses: actions/checkout@v3
+      - name: Select Xcode 13.4.1
+        run: sudo xcode-select -s /Applications/Xcode_13.4.1.app
       - name: Run tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,13 @@ test:
 		-scheme combine-schedulers \
 		-destination platform="$(PLATFORM_WATCHOS)"
 
+build-for-library-evolution:
+	swift build \
+		-c release \
+		--target CombineSchedulers \
+		-Xswiftc -emit-module-interface \
+		-Xswiftc -enable-library-evolution
+
 format:
 	swift format --in-place --recursive ./Package.swift ./Sources ./Tests
 

--- a/Sources/CombineSchedulers/Timer.swift
+++ b/Sources/CombineSchedulers/Timer.swift
@@ -80,14 +80,14 @@
     /// scheduler.advance(by: 1_000)
     /// XCTAssertEqual(output, Array(0...1_001))
     /// ```
-    public final class Timer<S: Scheduler>: ConnectablePublisher {
-      public typealias Output = S.SchedulerTimeType
+    public final class Timer<Scheduler: Combine.Scheduler>: ConnectablePublisher {
+      public typealias Output = Scheduler.SchedulerTimeType
       public typealias Failure = Never
 
-      public let interval: S.SchedulerTimeType.Stride
-      public let options: S.SchedulerOptions?
-      public let scheduler: S
-      public let tolerance: S.SchedulerTimeType.Stride?
+      public let interval: Scheduler.SchedulerTimeType.Stride
+      public let options: Scheduler.SchedulerOptions?
+      public let scheduler: Scheduler
+      public let tolerance: Scheduler.SchedulerTimeType.Stride?
 
       private lazy var routingSubscription: RoutingSubscription = {
         return RoutingSubscription(parent: self)
@@ -99,10 +99,10 @@
       }
 
       public init(
-        every interval: S.SchedulerTimeType.Stride,
-        tolerance: S.SchedulerTimeType.Stride? = nil,
-        scheduler: S,
-        options: S.SchedulerOptions? = nil
+        every interval: Scheduler.SchedulerTimeType.Stride,
+        tolerance: Scheduler.SchedulerTimeType.Stride? = nil,
+        scheduler: Scheduler,
+        options: Scheduler.SchedulerOptions? = nil
       ) {
         self.interval = interval
         self.options = options
@@ -115,7 +115,7 @@
       private class RoutingSubscription: Subscription, Subscriber, CustomStringConvertible,
         CustomReflectable, CustomPlaygroundDisplayConvertible
       {
-        typealias Input = S.SchedulerTimeType
+        typealias Input = Scheduler.SchedulerTimeType
         typealias Failure = Never
 
         private typealias ErasedSubscriber = AnySubscriber<Output, Failure>
@@ -155,7 +155,7 @@
         var playgroundDescription: Any { return description }
         var combineIdentifier: CombineIdentifier { return inner.combineIdentifier }
 
-        init(parent: Publishers.Timer<S>) {
+        init(parent: Publishers.Timer<Scheduler>) {
           self.lock = Lock()
           self.inner = .init(parent, self)
         }
@@ -246,13 +246,13 @@
       private final class Inner<Downstream: Subscriber>: NSObject, Subscription, CustomReflectable,
         CustomPlaygroundDisplayConvertible
       where
-        Downstream.Input == S.SchedulerTimeType,
+        Downstream.Input == Scheduler.SchedulerTimeType,
         Downstream.Failure == Never
       {
         private var cancellable: Cancellable?
         private let lock: Lock
         private var downstream: Downstream?
-        private var parent: Parent<S>?
+        private var parent: Parent<Scheduler>?
         private var started: Bool
         private var demand: Subscribers.Demand
 
@@ -270,7 +270,7 @@
         }
         var playgroundDescription: Any { return description }
 
-        init(_ parent: Parent<S>, _ downstream: Downstream) {
+        init(_ parent: Parent<Scheduler>, _ downstream: Downstream) {
           self.lock = Lock()
           self.parent = parent
           self.downstream = downstream


### PR DESCRIPTION
Not sure if this is a Swift bug or not, but 5.8 introduces an issue where an `S` method generic collides with an `S` type generic:

```
CombineSchedulers.build/CombineSchedulers.swiftinterface:302:81: error: 'SchedulerTimeType' is not a member type of type 'S'
    final public func receive<S>(subscriber: S) where S : Combine.Subscriber, S.SchedulerTimeType == S.Input, S.Failure == Swift.Never
                                                                              ~ ^
CombineSchedulers.build/CombineSchedulers.swiftinterface:1:1: error: failed to verify module interface of 'CombineSchedulers' due to the errors above; the textual interface may be broken by project issues or a compiler bug
// swift-interface-format-version: 1.0
^
```

This is preventing TCA from running library evolution CI on 5.8: https://github.com/pointfreeco/swift-composable-architecture/pull/2060