### PR TITLE
Update the framework to be safe in application extension

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,12 @@ let package = Package(
       name: "CombineSchedulers",
       dependencies: [
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay")
+      ],
+      swiftSettings: [
+        .unsafeFlags(["-Xfrontend", "-application-extension"])
+      ],
+      linkerSettings: [
+        .unsafeFlags(["-Xlinker", "-application_extension"])
       ]
     ),
     .testTarget(


### PR DESCRIPTION
### PR Description:
Right now, adding the framework as a dependency to an iOS project that has app extensions will throw the following warning:
```
warning linking against a dylib which is not safe for use in application extensions
```
Unfortunately, SPM doesn't offer a build setting such as `APPLICATION_EXTENSION_API_ONLY` and the only workaround that I found is adding this build option. This should throw a warning when adding an API that is unsafe for app extensions, e.g., `UIApplication.shared`.