### PR TITLE
Swift Language Support: Drop <5.9, Add 6.0

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -34,12 +34,6 @@ let package = Package(
         "CombineSchedulers"
       ]
     ),
-  ]
+  ],
+  swiftLanguageVersions: [.v6]
 )
-
-for target in package.targets {
-  target.swiftSettings = target.swiftSettings ?? []
-  target.swiftSettings!.append(contentsOf: [
-    .enableExperimentalFeature("StrictConcurrency")
-  ])
-}

--- a/Sources/CombineSchedulers/Concurrency.swift
+++ b/Sources/CombineSchedulers/Concurrency.swift
@@ -1,5 +1,5 @@
 #if canImport(Combine)
-  import Combine
+  @preconcurrency import Combine
 
   extension Scheduler {
     /// Suspends the current task for at least the given duration.

--- a/Sources/CombineSchedulers/UIScheduler.swift
+++ b/Sources/CombineSchedulers/UIScheduler.swift
@@ -1,6 +1,6 @@
 #if canImport(Combine)
   import Combine
-  import Dispatch
+  @preconcurrency import Dispatch
 
   /// A scheduler that executes its work on the main queue as soon as possible.
   ///


### PR DESCRIPTION
We can drop Swift <5.9 now that the App Store requires Xcode 15 for submissions, and we can add 6.0 language mode to keep our concurrency story in check.