### PR TITLE
Update Package@swift-6.0.swift

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -35,5 +35,5 @@ let package = Package(
       ]
     ),
   ],
-  swiftLanguageVersions: [.v6]
+  swiftLanguageModes: [.v6]
 )


### PR DESCRIPTION
I'm on a roll 😆

```
'combine-schedulers': /__w/SwiftPackageIndex-Server/SwiftPackageIndex-Server/.build/checkouts/combine-schedulers/Package@swift-6.0.swift:5:15: warning: 'init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)' is deprecated: replaced by 'init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageModes:cLanguageStandard:cxxLanguageStandard:)'
```