### PR TITLE
Add Android platform support (via Skip) for OpenCombineShim

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .product(
           name: "OpenCombineShim",
           package: "OpenCombine",
-          condition: .when(platforms: [.linux], traits: ["OpenCombineSchedulers"])
+          condition: .when(platforms: [.linux, .android])
         ),
       ]
     ),


### PR DESCRIPTION
Android (via [Skip](https://github.com/orgs/skiptools)) always requires OpenCombine since there's no native Combine. The traits mechanism doesn't work in Skip's build pipeline, so Android needs to be added without the trait condition.

As I understand it, Linux behavior is functionally unchanged since the trait is auto-enabled by default on non-Darwin platforms anyway (see preprocessor condition below, found at the bottom of Package.swift)

```
#if !canImport(Darwin)
  package.traits.insert(
    .default(enabledTraits: ["OpenCombineSchedulers"])
  )
#endif
```