### PR TITLE
Update OpenCombineShim condition to add Android

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2"),
+    .package(url: "https://github.com/pnewell/swift-issue-reporting", branch: "main"),
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.14.0"),
   ],
   targets: [
@@ -32,7 +32,7 @@ let package = Package(
       name: "CombineSchedulers",
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
-        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "swift-issue-reporting"),
         .product(
           name: "OpenCombineShim",
           package: "OpenCombine",

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .product(
           name: "OpenCombineShim",
           package: "OpenCombine",
-          condition: .when(platforms: [.linux], traits: ["OpenCombineSchedulers"])
+          condition: .when(platforms: [.linux, .android], traits: ["OpenCombineSchedulers"])
         ),
       ]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
-    .package(url: "https://github.com/pnewell/swift-issue-reporting", branch: "main"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2"),
     .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.14.0"),
   ],
   targets: [
@@ -32,7 +32,7 @@ let package = Package(
       name: "CombineSchedulers",
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
-        .product(name: "IssueReporting", package: "swift-issue-reporting"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         .product(
           name: "OpenCombineShim",
           package: "OpenCombine",


### PR DESCRIPTION
Building Android currently chokes when building Timer.swift because it does meet:
```
#if !(os(iOS) && (arch(i386) || arch(arm)))
```
But does not currently have access to Combine or OpenCombineShim, so neither get imported.